### PR TITLE
Output changes

### DIFF
--- a/R/estimate_R0.R
+++ b/R/estimate_R0.R
@@ -11,6 +11,8 @@
 #' for all windows.
 #' @param si_samples Numeric, the number of samples to take from the serial intervals supplied
 #' @param rt_samples Numeric, the number of samples to take from the estimated R distribution for each time point.
+#' @param wait_time Numeric, defaults to 7. The number of data points to wait for before starting to produce Rt estimates.
+#' The minimum value for this is 2. 
 #' @inheritParams add_dates
 #' @return A tibble containing the date and summarised R estimte.
 #' @export
@@ -37,7 +39,7 @@
 estimate_R0 <- function(cases = NULL, serial_intervals = NULL,
                         rt_prior = NULL, windows = NULL, 
                         si_samples = 100, rt_samples = 100,
-                        return_best = TRUE) {
+                        return_best = TRUE, wait_time = 7) {
 
  
   ## Adjust input based on the presence of imported cases
@@ -78,7 +80,7 @@ estimate_R0 <- function(cases = NULL, serial_intervals = NULL,
     est_r <- purrr::map_dfr(windows, 
                         function(window) {
                           
-                          window_start <- seq(2, nrow(incid) - (window - 1))
+                          window_start <- seq(wait_time, nrow(incid) - (window - 1))
                           window_end <- window_start + window - 1
                           
                           

--- a/R/estimate_time_varying_measures_for_cases.R
+++ b/R/estimate_time_varying_measures_for_cases.R
@@ -25,7 +25,10 @@ estimate_time_varying_measures_for_cases <- function(cases = NULL,
   R0_estimates <- cases %>%
     EpiNow::estimate_R0(serial_intervals = serial_intervals,
                         si_samples = si_samples, rt_samples = rt_samples,
-                        windows = rt_windows, rt_prior = rt_prior) %>%
+                        windows = rt_windows, rt_prior = rt_prior)
+  
+  
+  R0_estimates_sum <- R0_estimates %>% 
     dplyr::group_by(date) %>%
     dplyr::summarise(
       bottom  = purrr::map_dbl(list(HDInterval::hdi(R, credMass = 0.9)), ~ .[[1]]),
@@ -63,7 +66,8 @@ estimate_time_varying_measures_for_cases <- function(cases = NULL,
     dplyr::select(-data)
 
 
-  out <- list(R0_estimates, little_r_estimates)
+  out <- list(R0_estimates_sum, little_r_estimates_res, R0_estimates)
+  names(out) <- c("R0", "rate_of_spread", "raw_R0")
 
   return(out)
 }

--- a/R/estimate_time_varying_measures_for_nowcast.R
+++ b/R/estimate_time_varying_measures_for_nowcast.R
@@ -112,7 +112,8 @@ estimate_time_varying_measures_for_nowcast <- function(nowcast = NULL,
                                                              .progress = TRUE)
 
 
-  out <- list(R0_estimates_sum, little_r_estimates_res)
+  out <- list(R0_estimates_sum, little_r_estimates_res, R0_estimates)
+  names(out) <- c("R0", "rate_of_spread", "raw_R0")
 
   return(out)
 }

--- a/R/get_timeseries.R
+++ b/R/get_timeseries.R
@@ -3,22 +3,42 @@
 #' @param results_dir A character string indicating the folder containing the `EpiNow`
 #' results to extract.
 #' @param date A Character string (in the format "yyyy-mm-dd") indicating the date to extract
-#' data for
-#'
+#' data for. Defaults to "latest" which finds the latest results available.
+#' @param summarised Logical, defaults to `FALSE`. Should full or summarised results be 
+#' returned. 
 #' @return
 #' @export
 #' @importFrom purrr map_dfr safely
 #' @examples
 #'
+#'
+#' \dontrun{
+#' ## Assuming epiforecasts/covid is one repo higher
+#' ## Summary results
+#' get_timeseries("../covid/_posts/global/nowcast/results/", 
+#'                summarised = TRUE)
+#' 
+#' ## Simulations
+#' get_timeseries("../covid/_posts/global/nowcast/results/")
+#' }
 #' ## Code
 #' get_timeseries
-get_timeseries <- function(results_dir = NULL, date = NULL) {
+get_timeseries <- function(results_dir = NULL, date = NULL,
+                           summarised = FALSE) {
 
   ## Assign to latest likely date if not given
   if (is.null(date)) {
-    date <- Sys.Date() - 1
+    date <- "latest"
   }
 
+  if (summarised) {
+    nowcast <- "summarised_nowcast.rds"
+    rt_index <- 1
+  } else{
+    nowcast <- "nowcast.rds"
+    rt_index <- 3
+  }
+  
   ## Find all regions
   regions <- list.files(results_dir)
   names(regions) <- regions
@@ -28,12 +48,12 @@ get_timeseries <- function(results_dir = NULL, date = NULL) {
   ## Get rt values and combine
   rt <- purrr::map_dfr(regions, ~ load_data("time_varying_params.rds", .,
                                         result_dir = results_dir,
-                                        date = date)[[3]][[1]],
+                                        date = date)[[1]][[rt_index]],
                         .id = "region")
 
 
   ## Get incidence values and combine
-  incidence <- purrr::map_dfr(regions, ~ load_data("nowcast.rds", .,
+  incidence <- purrr::map_dfr(regions, ~ load_data(nowcast, .,
                                                    result_dir = results_dir,
                                                    date = date)[[1]],
                               .id = "region")

--- a/R/get_timeseries.R
+++ b/R/get_timeseries.R
@@ -28,12 +28,12 @@ get_timeseries <- function(results_dir = NULL, date = NULL) {
   ## Get rt values and combine
   rt <- purrr::map_dfr(regions, ~ load_data("time_varying_params.rds", .,
                                         result_dir = results_dir,
-                                        date = date)[[1]][[1]],
+                                        date = date)[[3]][[1]],
                         .id = "region")
 
 
   ## Get incidence values and combine
-  incidence <- purrr::map_dfr(regions, ~ load_data("summarised_nowcast.rds", .,
+  incidence <- purrr::map_dfr(regions, ~ load_data("nowcast.rds", .,
                                                    result_dir = results_dir,
                                                    date = date)[[1]],
                               .id = "region")

--- a/R/rt_pipeline.R
+++ b/R/rt_pipeline.R
@@ -23,7 +23,7 @@
 #' @param rt_samples Numeric, the number of samples to take from the estimated R distribution for each time point.
 #' @param rt_prior A list defining the reproduction number prior containing the mean (`mean_prior`) and standard deviation (`std_prior`)
 #' @param verbose Logical, defaults to `FALSE`. Should internal nowcasting progress messages be returned.
-#' @param save_plots Logical, defaults to code `TRUE`. Should plots be saved.
+#' @param save_plots Logical, defaults to `TRUE`. Should plots be saved.
 #' @return NULL
 #' @export
 #' @inheritParams estimate_time_varying_measures_for_nowcast
@@ -120,7 +120,7 @@ target_folder <- file.path(target_folder, target_date)
 
   summarise_cast <- EpiNow::summarise_cast(nowcast)
 
-  ## Combine nowcast with observed cases by onset and repor
+  ## Combine nowcast with observed cases by onset and report
   reported_cases <- cases %>%
     dplyr::count(date, wt = confirm) %>%
     dplyr::select(date, median = n) %>%

--- a/man/estimate_R0.Rd
+++ b/man/estimate_R0.Rd
@@ -11,7 +11,8 @@ estimate_R0(
   windows = NULL,
   si_samples = 100,
   rt_samples = 100,
-  return_best = TRUE
+  return_best = TRUE,
+  wait_time = 7
 )
 }
 \arguments{
@@ -31,6 +32,9 @@ selected per serial interval sample by default (based on which window best forec
 
 \item{return_best}{Logical defaults to \code{TRUE}. Should the estimates for the best performing window be returned or estimates
 for all windows.}
+
+\item{wait_time}{Numeric, defaults to 7. The number of data points to wait for before starting to produce Rt estimates.
+The minimum value for this is 2.}
 }
 \value{
 A tibble containing the date and summarised R estimte.

--- a/man/get_timeseries.Rd
+++ b/man/get_timeseries.Rd
@@ -4,14 +4,17 @@
 \alias{get_timeseries}
 \title{Get Timeseries from EpiNow}
 \usage{
-get_timeseries(results_dir = NULL, date = NULL)
+get_timeseries(results_dir = NULL, date = NULL, summarised = FALSE)
 }
 \arguments{
 \item{results_dir}{A character string indicating the folder containing the \code{EpiNow}
 results to extract.}
 
 \item{date}{A Character string (in the format "yyyy-mm-dd") indicating the date to extract
-data for}
+data for. Defaults to "latest" which finds the latest results available.}
+
+\item{summarised}{Logical, defaults to \code{FALSE}. Should full or summarised results be
+returned.}
 }
 \value{
 
@@ -21,6 +24,16 @@ Get Timeseries from EpiNow
 }
 \examples{
 
+
+\dontrun{
+## Assuming epiforecasts/covid is one repo higher
+## Summary results
+get_timeseries("../covid/_posts/global/nowcast/results/", 
+               summarised = TRUE)
+
+## Simulations
+get_timeseries("../covid/_posts/global/nowcast/results/")
+}
 ## Code
 get_timeseries
 }

--- a/man/rt_pipeline.Rd
+++ b/man/rt_pipeline.Rd
@@ -69,7 +69,7 @@ that day. Defaults to \code{EpiNow::covid_serial_intervals}.}
 
 \item{rt_prior}{A list defining the reproduction number prior containing the mean (\code{mean_prior}) and standard deviation (\code{std_prior})}
 
-\item{save_plots}{Logical, defaults to code \code{TRUE}. Should plots be saved.}
+\item{save_plots}{Logical, defaults to \code{TRUE}. Should plots be saved.}
 }
 \description{
 Combine fitting a delay distribution, constructing a set of


### PR DESCRIPTION
* Added a `wait_time` argument to `estimate_R0` that defaults to 7 days. This controls when `EpiEstim` starts trying to return Rt estimates but does not guarantee that estimates will exist as it does its own checking.

* Added full Rt samples to the save data object. 

* Updated `get_timeseries` to default to the latest data and to the full results (currently not present for `covid` results. Added a `summarised` argument to get back to the old behaviour. (Useful for @nikosbosse and time series modelling downstream)