### PR TITLE
External report delay

### DIFF
--- a/R/epi_measures_pipeline.R
+++ b/R/epi_measures_pipeline.R
@@ -170,7 +170,7 @@ epi_measures_pipeline <- function(nowcast = NULL,
   out <- list(R0_estimates_sum, little_r_estimates_res, R0_estimates)
   names(out) <- c("R0", "rate_of_spread", "raw_R0")
 
-  if (!is.null(cases_forecast)) {
+  if (!(is.null(cases_forecast) | length(cases_forecast) == 0)) {
     
     out$case_forecast <- sum_cases_forecast
     out$raw_case_forecast <- cases_forecast

--- a/R/epi_measures_pipeline.R
+++ b/R/epi_measures_pipeline.R
@@ -16,12 +16,12 @@
 #' @examples 
 #'
 epi_measures_pipeline <- function(nowcast = NULL,
-                                                       serial_intervals = NULL,
-                                                       min_est_date = NULL,
-                                                       si_samples = NULL, rt_samples = NULL,
-                                                       rt_windows = 7, rate_window = 7,
-                                                       rt_prior = NULL, forecast_model = NULL,
-                                                       horizon = NULL) {
+                                  serial_intervals = NULL,
+                                  min_est_date = NULL,
+                                  si_samples = NULL, rt_samples = NULL,
+                                  rt_windows = 7, rate_window = 7,
+                                  rt_prior = NULL, forecast_model = NULL,
+                                  horizon = NULL) {
 
   ## Estimate time-varying R0
   safe_R0 <- purrr::safely(EpiNow::estimate_R0)
@@ -29,7 +29,7 @@ epi_measures_pipeline <- function(nowcast = NULL,
   message("Estimate time-varying R0")
   data_list <-  dplyr::group_split(nowcast, type, sample, keep = TRUE)
 
-
+ 
   estimates <- furrr::future_map(data_list, function(data) {
     estimates <- safe_R0(cases = data,
             serial_intervals = serial_intervals,
@@ -99,7 +99,7 @@ epi_measures_pipeline <- function(nowcast = NULL,
     purrr::compact()
     
     
-  if (!is.null(cases_forecast)) {
+  if (!(is.null(cases_forecast) | length(cases_forecast) == 0)) {
     
     ## Clean up case forecasts
     cases_forecast <- cases_forecast %>% 

--- a/R/estimate_R0.R
+++ b/R/estimate_R0.R
@@ -163,14 +163,14 @@ estimate_R0 <- function(cases = NULL, serial_intervals = NULL,
                           ## Score the forecast
                           scores <- EpiSoon::score_case_forecast(preds, summed_cases)
                           
-                          ## Evaluate the window using the mean CRPS across all time points and samples
+                          ## Evaluate the window using the median CRPS across all time points and samples
                           summarised_score <- scores %>% 
-                            dplyr::summarise(mean = mean(crps, na.rm = TRUE),
+                            dplyr::summarise(median = median(crps, na.rm = TRUE),
                                              sd = sd(crps, na.rm = TRUE))
                           
                           out <- out %>% 
                             dplyr::mutate(
-                              score = summarised_score$mean,
+                              score = summarised_score$median,
                               score_sd = summarised_score$sd,
                               window = window
                             )

--- a/R/nowcast_pipeline.R
+++ b/R/nowcast_pipeline.R
@@ -30,18 +30,16 @@ nowcast_pipeline <- function(reported_cases = NULL, linelist = NULL,
                              samples = 1,
                              report_delay_fns = NULL,
                              nowcast_lag = 4) {
-
-
-  ## Get the distribution of reporting delays
-  ## Look at reporting delays over the two weeks
-  if (is.null(date_to_cutoff_delay)) {
-    date_to_cutoff_delay <- min(linelist$date_confirmation, na.rm = TRUE)
-  }
-
-  message("Fitting reporting delay between the ", date_to_cutoff_delay, " and the ", date_to_cast)
-
-
+ 
   if (is.null(report_delay_fns)) {
+    
+    ## Get the distribution of reporting delays
+    ## Look at reporting delays over the two weeks
+    if (is.null(date_to_cutoff_delay)) {
+      date_to_cutoff_delay <- min(linelist$date_confirmation, na.rm = TRUE)
+    }
+    
+    message("Fitting reporting delay between the ", date_to_cutoff_delay, " and the ", date_to_cast)
     ## Filter linelist for target delay distribution dates
     filtered_linelist <- linelist %>%
       dplyr::filter(date_confirmation >= date_to_cutoff_delay,
@@ -50,12 +48,11 @@ nowcast_pipeline <- function(reported_cases = NULL, linelist = NULL,
     
     ## Fit the delay distribution and draw posterior samples
     fitted_delay_fn <- EpiNow::get_delay_sample_fn(filtered_linelist, samples = samples)
+    
+
 
   }else{
     fitted_delay_fn <- report_delay_fns
-    message("A set of report delays functions has been passed to the pipeline so a report delay will not be 
-            fit.")
-    message("Nowcasting for ", length(report_delay_fns), " based on the report delay functions passed in")
   }
 
   ## Group linelists by day
@@ -200,8 +197,7 @@ nowcast_pipeline <- function(reported_cases = NULL, linelist = NULL,
 
 
 # Nowcast samples ---------------------------------------------------------
-
-message("Nowcasting using fitted delay distributions")
+  message("Nowcasting using fitted delay distributions")
   out <- furrr::future_map_dfr(fitted_delay_fn,
                                ~ nowcast_inner(delay_fn = ., verbose),
                                .progress = TRUE,

--- a/R/regional_rt_pipeline.R
+++ b/R/regional_rt_pipeline.R
@@ -80,9 +80,17 @@ regional_rt_pipeline <- function(cases = NULL, linelist = NULL, target_folder = 
   ## regional pipelines
   regions <- unique(cases$region)
   
-  if (regional_delay) {
-    message("Using a national linelist so setting merge onsets to FALSE for regional analysis")
+  if (!regional_delay) {
+    message("Using a national linelist so not merging onsets and fitting a single reporting delay")
     merge_onsets <- FALSE
+    
+    ## Fit the delay distribution
+    report_delay_fns <-  linelist %>%
+      dplyr::rename(delay_confirmation = report_delay) %>% 
+      EpiNow::get_delay_sample_fn(samples = samples)  
+    
+  }else{
+    report_delay_fns <- NULL
   }
   
   message("Running pipelines by region")
@@ -108,7 +116,8 @@ regional_rt_pipeline <- function(cases = NULL, linelist = NULL, target_folder = 
       target_folder = file.path(target_folder, target_region),
       target_date = target_date, 
       merge_actual_onsets = merge_onsets, 
-      samples = samples, ...)
+      samples = samples, ..., 
+      report_delay_fns = report_delay_fns)
     
     
     return(invisible(NULL))

--- a/R/rt_pipeline.R
+++ b/R/rt_pipeline.R
@@ -41,7 +41,7 @@ rt_pipeline <- function(cases = NULL, imported_cases = NULL, linelist = NULL,
                         merge_actual_onsets = TRUE, delay_only = FALSE,
                         verbose = FALSE, serial_intervals = NULL, rt_prior = NULL, save_plots = TRUE,
                         nowcast_lag = 4, incubation_period = 5, forecast_model = NULL,
-                        horizon = NULL) {
+                        horizon = NULL, report_delay_fns = NULL) {
  
  
 # Set up folders ----------------------------------------------------------
@@ -101,7 +101,7 @@ target_folder <- file.path(target_folder, target_date)
                                       earliest_allowed_onset = earliest_allowed_onset,
                                       merge_actual_onsets = merge_actual_onsets, samples = samples,
                                       delay_only = delay_only, nowcast_lag = nowcast_lag,
-                                      verbose = verbose)
+                                      verbose = verbose, report_delay_fns = report_delay_fns)
 
 
 

--- a/man/nowcast_pipeline.Rd
+++ b/man/nowcast_pipeline.Rd
@@ -14,6 +14,7 @@ nowcast_pipeline(
   delay_only = FALSE,
   verbose = FALSE,
   samples = 1,
+  report_delay_fns = NULL,
   nowcast_lag = 4
 )
 }
@@ -35,6 +36,8 @@ Should linelist onset dates be used where available?}
 \item{verbose}{Logical, defaults to \code{FALSE}. Should internal nowcasting progress messages be returned.}
 
 \item{samples}{Numeric, the number of samples to take.}
+
+\item{report_delay_fns}{List of functions as produced by \code{EpiNow::get_delay_sample_fn}}
 
 \item{nowcast_lag}{Numeric, defaults to 4. The number of days by which to lag nowcasts. Helps reduce bias due to case upscaling.}
 

--- a/man/rt_pipeline.Rd
+++ b/man/rt_pipeline.Rd
@@ -27,7 +27,8 @@ rt_pipeline(
   nowcast_lag = 4,
   incubation_period = 5,
   forecast_model = NULL,
-  horizon = NULL
+  horizon = NULL,
+  report_delay_fns = NULL
 )
 }
 \arguments{
@@ -77,6 +78,8 @@ that day. Defaults to \code{EpiNow::covid_serial_intervals}.}
 future Rt values. An example of the required structure is: \code{function(ss, y){bsts::AddSemilocalLinearTrend(ss, y = y)}}.}
 
 \item{horizon}{Numeric, defaults to 0. The horizon over which to forecast Rts and cases.}
+
+\item{report_delay_fns}{List of functions as produced by \code{EpiNow::get_delay_sample_fn}}
 }
 \description{
 Combine fitting a delay distribution, constructing a set of


### PR DESCRIPTION
* Moved from using the mean to using the median to select a window
* Made fitting a report delay optional in nowcast pipeline and cascaded the changes through other functions (left in the need for a linelist that is now not actually used anywhere -> should improve this later)
* If no regional delay is specified then a report delay is fit for all regions in `regional_rt_pipeline` and passed into the `rt_pipeline` for each region 
* Additional error checking for when a nowcast is possible but a forecast is not. 

Tested all changes both with and without a passed in delay on the UK regions and nationally