### PR TITLE
Forecast tweaks

### DIFF
--- a/R/plot_forecast.R
+++ b/R/plot_forecast.R
@@ -16,13 +16,13 @@ plot_forecast <- function(plot = NULL, forecast = NULL) {
       ggplot2::geom_ribbon(data = forecast,
                            ggplot2::aes(ymin = bottom, ymax = top,
                                         fill = "Forecast"),
-                           alpha = 0.1) +
+                           alpha = 0.075) +
       ggplot2::geom_ribbon(data = forecast,
                            ggplot2::aes(ymin = lower, ymax = upper,
                                         fill = "Forecast"),
-                           alpha = 0.2) + 
-      ggplot2::geom_line(data = forecast, ggplot2::aes(y = bottom, alpha = 1)) +
-      ggplot2::geom_line(data = forecast, ggplot2::aes(y = top, alpha =  1))
+                           alpha = 0.125) + 
+      ggplot2::geom_line(data = forecast, ggplot2::aes(y = bottom, alpha = 0.5)) +
+      ggplot2::geom_line(data = forecast, ggplot2::aes(y = top, alpha =  0.5))
     
   }
 

--- a/R/plot_summary.R
+++ b/R/plot_summary.R
@@ -27,11 +27,11 @@ plot_summary <- function(summary_results, x_lab = "Region", log_cases = FALSE) {
       ggplot2::facet_wrap(~ metric, ncol = 1, scales = "free_y") +
       cowplot::theme_cowplot() +
       cowplot::panel_border() +
-      ggplot2::scale_color_manual( values = c(
-        "Increasing" = "#1170aa",
-        "Likely increasing" = "#5fa2ce",
-        "Likely decreasing" = "#fc7d0b",
-        "Decreasing" = "#c85200",
+      ggplot2::scale_color_manual(   values = c(
+        "Increasing" = "#e75f00",
+        "Likely increasing" = "#fd9e49",
+        "Likely decreasing" = "#5fa2ce",
+        "Decreasing" = "#1170aa",
         "Unsure" = "#7b848f"), drop = FALSE) 
   }
   

--- a/R/report_estimates.R
+++ b/R/report_estimates.R
@@ -246,7 +246,7 @@ report_estimates <- function(cases = NULL, nowcast = NULL,
     tidyr::unnest("report_overall") %>%
     dplyr::select(Data = type,
                   `Rate of growth` = little_r,
-                  `Doubling time (days)` = doubling_time,
+                  `Doubling/halving time (days)` = doubling_time,
                   `Adjusted R-squared` = goodness_of_fit
     )
   
@@ -283,7 +283,7 @@ report_estimates <- function(cases = NULL, nowcast = NULL,
     tidyr::spread(key = "vars", value = "range") %>%
     dplyr::select(Data = type,
                   `Rate of growth` = little_r,
-                  `Doubling time (days)` = doubling_time,
+                  `Doubling/halving time (days)` = doubling_time,
                   `Adjusted R-squared` = goodness_of_fit
     )
   
@@ -323,7 +323,7 @@ report_estimates <- function(cases = NULL, nowcast = NULL,
     dplyr::mutate(vars = vars %>%
                     factor(levels = c("little_r", "doubling_time", "goodness_of_fit"),
                            labels = c("Rate of growth",
-                                      "Doubling time (days)",
+                                      "Doubling/halving time (days)",
                                       "Adjusted R-squared")
                     ))
   
@@ -346,7 +346,7 @@ report_estimates <- function(cases = NULL, nowcast = NULL,
     ggplot2::labs(tag = "A")
   
   plot_doublingtime <- plot_littler_data %>%
-    plot_littler_fn(plot_var = "Doubling time (days)") +
+    plot_littler_fn(plot_var = "Doubling/halving time (days)") +
     ggplot2::coord_cartesian(ylim=c(-40, 40)) +
     ggplot2::labs(tag = "B")
   
@@ -423,7 +423,7 @@ report_estimates <- function(cases = NULL, nowcast = NULL,
     measure = c("New confirmed cases by infection date",
                 "Expected change in daily cases",
                 "Effective reproduction no.",
-                "Doubling time (days)",
+                "Doubling/halving time (days)",
                 "Adjusted R-squared"),
     estimate = c(
       current_cases %>% 

--- a/R/summarise_results.R
+++ b/R/summarise_results.R
@@ -42,7 +42,7 @@ summarise_results <- function(regions = NULL,
       map_prob_change(),
     `Effective reproduction no.` =  regions %>% 
       purrr::map(~ load_data("bigr_eff_latest.rds", .)),
-    `Doubling time (days)` = regions %>% 
+    `Doubling/halving time (days)` = regions %>% 
       purrr::map_chr(~ load_data("doubling_time_latest.rds", .))) 
    
   

--- a/R/theme_map.R
+++ b/R/theme_map.R
@@ -33,10 +33,10 @@ theme_map <- function(map = NULL, continuous = FALSE,
   if (is.null(scale_fill)) {
     scale_fill = ggplot2::scale_fill_manual
     values <- c(
-      "Increasing" = "#1170aa",
-      "Likely increasing" = "#5fa2ce",
-      "Likely decreasing" = "#fc7d0b",
-      "Decreasing" = "#c85200",
+      "Increasing" = "#e75f00",
+      "Likely increasing" = "#fd9e49",
+      "Likely decreasing" = "#5fa2ce",
+      "Decreasing" = "#1170aa",
       "Unsure" = "#7b848f")
   }
   

--- a/inst/templates/_region-report.Rmd
+++ b/inst/templates/_region-report.Rmd
@@ -37,7 +37,7 @@ knitr::include_graphics(here::here(file.path(region_path, region, "latest/rt_cas
 ```
 
 <br>
-`r paste0("*Figure ",  summary_figures + 1 + (index - 1) * 2, ": A.) Confirmed cases by date of report (bars) and their estimated date of infection. B.) Time-varying estimate of the effective reproduction number. Light ribbon = 90% credible interval; dark ribbon = the 50% credible interval. Estimates are shown until the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),  ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ",  summary_figures + 1 + (index - 1) * 2, ": A.) Confirmed cases by date of report (bars) and their estimated date of infection. B.) Time-varying estimate of the effective reproduction number. Light ribbon = 90% credible interval; dark ribbon = the 50% credible interval. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),  ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
 
 `r paste(c(rep("#", title_depth), " Time-varying rate of growth and doubling time"), collapse = "")`
 
@@ -46,5 +46,5 @@ knitr::include_graphics(here::here(file.path(region_path, region, "latest/rate_s
 ```
 
 <br>
-`r paste0("*Figure ",  summary_figures + 2 + (index - 1) * 2, ": A.) Time-varying estimate of the rate of growth, B.) Time-varying estimate of the doubling time in days (when negative this corresponds to the halving time), C.) The adjusted R-squared estimates indicating the goodness of fit of the exponential regression model (with values closer to 1 indicating a better fit).  Estimates are shown until the ", latest_date,  ". Light ribbon = 90% credible interval; dark ribbon = the 50% credible interval. Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence.*")`
+`r paste0("*Figure ",  summary_figures + 2 + (index - 1) * 2, ": A.) Time-varying estimate of the rate of growth, B.) Time-varying estimate of the doubling time in days (when negative this corresponds to the halving time), C.) The adjusted R-squared estimates indicating the goodness of fit of the exponential regression model (with values closer to 1 indicating a better fit).  Estimates from existing data are shown up to the ", latest_date,  ". Light ribbon = 90% credible interval; dark ribbon = the 50% credible interval. Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence.*")`
 

--- a/inst/templates/_regional-summary.Rmd
+++ b/inst/templates/_regional-summary.Rmd
@@ -26,7 +26,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "summary_plot.png")))
 ```
 
 <br>
-`r paste0("*Figure ", fig_start, ": Confirmed cases with date of infection on the ", latest_date, " and the time-varying estimate of the effective reproduction number (light bar = 90% credible interval; dark bar = the 50% credible interval.). Regions are ordered by the number of expected daily confirmed cases and shaded based on the expected change in daily confirmed cases. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control and a single case required for elimination. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ", fig_start, ": Confirmed cases with date of infection on the ", latest_date, " and the time-varying estimate of the effective reproduction number (light bar = 90% credible interval; dark bar = the 50% credible interval.). Regions are ordered by the number of expected daily confirmed cases and shaded based on the expected change in daily confirmed cases. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control and a single case required for elimination.*")`
 
 ### Reproduction numbers over time in the six regions expected to have the most new confirmed cases
 

--- a/inst/templates/_regional-summary.Rmd
+++ b/inst/templates/_regional-summary.Rmd
@@ -35,7 +35,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "high_cases_rt_plot.p
 ```
 
 <br>
-`r paste0("*Figure ", fig_start + 1, ": Time-varying estimate of the effective reproduction number (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed cases. Estimates are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ", fig_start + 1, ": Time-varying estimate of the effective reproduction number (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed cases. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control. The vertical dashed line indicates the date of report generation.*")`
 
 ### Reported confirmed cases and their estimated date of infection in the six regions expected to have the most new confirmed cases
 
@@ -44,7 +44,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "high_cases_plot.png"
 ```
 
 <br>
-`r paste0("*Figure ", fig_start + 2, ": Confirmed cases by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed cases.  Estimates are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ", fig_start + 2, ": Confirmed cases by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed cases.  Estimates from existing data are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
 
 ### Reproduction numbers over time in all regions
 
@@ -53,7 +53,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "rt_plot.png")))
 ```
 
 <br>
-`r paste0("*Figure ",  fig_start + 3, ": Time-varying estimate of the effective reproduction number (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ",  fig_start + 3, ": Time-varying estimate of the effective reproduction number (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates from existing data are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control. The vertical dashed line indicates the date of report generation.*")`
 
 
 ### Reported confirmed cases and their estimated date of infection in all regions
@@ -62,7 +62,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "rt_plot.png")))
 knitr::include_graphics(here::here(file.path(summary_path, "cases_plot.png")))
 ```
 
-`r paste0("*Figure ",  fig_start + 4, ": Confirmed cases by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ",  fig_start + 4, ": Confirmed cases by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
 
 `r paste0("### Latest estimates (as of the ", latest_date, ")")`
 


### PR DESCRIPTION
* Swapped colours in palette around and muted red
* Switched from doubling time -> doubling/halving time
* Dropped mention of dotted line that doesn't exist
* Updated caption reference to target date
* Reduced alpha on forecast ribbon and outer line (25% ~ 50% reduction)

