### PR TITLE
Support varying mods by status

### DIFF
--- a/R/nowcast_pipeline.R
+++ b/R/nowcast_pipeline.R
@@ -240,6 +240,22 @@ if (!is.null(onset_modifier)) {
     sample_bin <- dplyr::mutate(sample_bin, 
                                 type = "nowcast", 
                                 import_status = "local")
+    
+    if (sum(imported_cases$confirm) > 0) {
+      ## sample neg bin
+      imported_sample_bin <- EpiNow::sample_onsets(
+        onsets = imported_cases_by_onset$cases,
+        dates = imported_cases_by_onset$date,
+        cum_freq = sample_delay_fn(1:nrow(imported_cases_by_onset), dist = TRUE),
+        report_delay = 0,
+        samples = 1
+      )[[1]]
+      
+      imported_sample_bin <- dplyr::mutate(imported_sample_bin, 
+                                           type = "nowcast", 
+                                           import_status = "imported")
+      
+    }
 
     ## Add in delay only estimates
     if (delay_only) {
@@ -263,8 +279,7 @@ if (!is.null(onset_modifier)) {
     if (sum(imported_cases$confirm) > 0) {
       out <-  
         dplyr::bind_rows(out, 
-          imported_cases_by_onset %>%
-            dplyr::mutate(type = "nowcast")
+                         imported_sample_bin
         )
     }
 

--- a/R/nowcast_pipeline.R
+++ b/R/nowcast_pipeline.R
@@ -218,7 +218,7 @@ if (!is.null(onset_modifier)) {
       
       if (!is.null(onset_modifier)) {
         imported_cases_by_onset <-  imported_cases_by_onset[onset_modifier, on = 'date'][!is.na(cases)][,
-                 cases := as.integer(purrr::map2_dbl(cases, modifier, ~ .x * (1 - .y(n = 1, status = "status"))))][,modifier := NULL]
+                 cases := as.integer(purrr::map2_dbl(cases, modifier, ~ .x * .y(n = 1, status = "import")))][,modifier := NULL]
       }
     }
       

--- a/R/regional_rt_pipeline.R
+++ b/R/regional_rt_pipeline.R
@@ -6,7 +6,6 @@
 #' @param linelist A dataframe of of cases (by row) containing the following variables:
 #' `import_status` (values "local" and "imported"), `date_onset`, `date_confirm`, `report_delay`, and `region`. If a national linelist is not available a proxy linelist may be 
 #' used but in this case `merge_onsets` should be set to `FALSE`.
-#' @param national Logical defaults to `FALSE`. Should a national summary nowcast be made.
 #' @param regional_delay Logical defaults to `FALSE`. Should reporting delays be estimated by region.
 #' @param merge_onsets Logical defaults to `FALSE`. Should available onset data be used. Typically if `regional_delay` is
 #' @param case_limit Numeric, the minimum number of cases in a region required for that region to be evaluated. Defaults to 10.
@@ -26,8 +25,8 @@
 #' ## Code
 #' regional_rt_pipeline
 regional_rt_pipeline <- function(cases = NULL, linelist = NULL, target_folder = "results", 
-                                 national = FALSE, regional_delay = FALSE, merge_onsets = FALSE,
-                                 case_limit = 40,
+                                 regional_delay = FALSE, merge_onsets = FALSE,
+                                 case_limit = 40, onset_modifier = NULL,
                                  regions_in_parallel = TRUE,
                                  verbose = FALSE,
                                  samples = 1000, ...) {
@@ -62,28 +61,6 @@ regional_rt_pipeline <- function(cases = NULL, linelist = NULL, target_folder = 
                     fill = list(cases = 0)) %>% 
     dplyr::ungroup()
   
-  
-  if (national) {
-    ## National cast
-    national_cases <- cases %>% 
-      dplyr::count(date, import_status, wt = cases) %>% 
-      dplyr::rename(cases = n)
-    
-    ## Run and save analysis pipeline
-    if (verbose) {
-      message("Running national Rt pipeline")
-    }
-
-    
-    rt_pipeline(
-      cases = national_cases,
-      linelist = linelist,
-      target_folder = file.path(target_folder, "national"),
-      target_date = target_date, 
-      merge_actual_onsets = merge_onsets, 
-      samples = samples, ...)
-    
-  }
 
   ## regional pipelines
   regions <- unique(cases$region)
@@ -119,6 +96,8 @@ regional_rt_pipeline <- function(cases = NULL, linelist = NULL, target_folder = 
     regional_cases <- cases %>% 
       dplyr::filter(region %in% target_region)
     
+    rm(cases)
+    
     if (regional_delay) {
       regional_linelist <- linelist %>% 
         dplyr::filter(region %in% target_region)
@@ -126,11 +105,21 @@ regional_rt_pipeline <- function(cases = NULL, linelist = NULL, target_folder = 
       regional_linelist <- linelist
     }
     
+    rm(linelist)
+    
+    if (!is.null(onset_modifier)) {
+      region_onset_modifier <- onset_modifier %>% 
+        dplyr::filter(region %in% "target_region") %>% 
+        dplyr::select(-region)
+      
+      rm(onset_modifier)
+    }
     region_rt(cases = regional_cases,
               linelist = regional_linelist,
+              onset_modifier = region_onset_modifier,
               target_folder = file.path(target_folder, target_region))
 
-    
+    rm(list = ls())
     
     return(invisible(NULL))
     

--- a/R/regional_rt_pipeline.R
+++ b/R/regional_rt_pipeline.R
@@ -96,8 +96,6 @@ regional_rt_pipeline <- function(cases = NULL, linelist = NULL, target_folder = 
     regional_cases <- cases %>% 
       dplyr::filter(region %in% target_region)
     
-    rm(cases)
-    
     if (regional_delay) {
       regional_linelist <- linelist %>% 
         dplyr::filter(region %in% target_region)
@@ -105,14 +103,11 @@ regional_rt_pipeline <- function(cases = NULL, linelist = NULL, target_folder = 
       regional_linelist <- linelist
     }
     
-    rm(linelist)
-    
     if (!is.null(onset_modifier)) {
       region_onset_modifier <- onset_modifier %>% 
         dplyr::filter(region %in% target_region) %>% 
         dplyr::select(-region)
-      
-      rm(onset_modifier)
+  
     }else{
       region_onset_modifier <- NULL
     }

--- a/R/regional_rt_pipeline.R
+++ b/R/regional_rt_pipeline.R
@@ -109,7 +109,7 @@ regional_rt_pipeline <- function(cases = NULL, linelist = NULL, target_folder = 
     
     if (!is.null(onset_modifier)) {
       region_onset_modifier <- onset_modifier %>% 
-        dplyr::filter(region %in% "target_region") %>% 
+        dplyr::filter(region %in% target_region) %>% 
         dplyr::select(-region)
       
       rm(onset_modifier)

--- a/R/regional_rt_pipeline.R
+++ b/R/regional_rt_pipeline.R
@@ -113,7 +113,10 @@ regional_rt_pipeline <- function(cases = NULL, linelist = NULL, target_folder = 
         dplyr::select(-region)
       
       rm(onset_modifier)
+    }else{
+      region_onset_modifier <- NULL
     }
+    
     region_rt(cases = regional_cases,
               linelist = regional_linelist,
               onset_modifier = region_onset_modifier,

--- a/R/sample_approx_delay.R
+++ b/R/sample_approx_delay.R
@@ -5,6 +5,8 @@
 #' `date` and `confirm`. 
 #' @param max_delay Numeric, maximum delay to allow. Defaults to 120 days
 #' @inheritParams sample_delay
+#' @param direction Character string, defato "onset". Direction in which to map cases. Supports
+#' either from report to onset ("onset") or from onset to report ("report")
 #' @return A `data.table` of cases by date of onset
 #' @export
 #' @importFrom purrr map_dfc
@@ -19,14 +21,24 @@
 #' 
 #' onsets <- sample_approx_delay(reported_cases = cases,
 #'                               delay_fn = delay_fn)
+#'                               
+#' reports <- sample_approx_delay(reported_cases = cases,
+#'                               delay_fn = delay_fn,
+#'                               direction = "report")
 #' 
 sample_approx_delay <- function(reported_cases = NULL, 
                                 delay_fn = NULL,
                                 max_delay = 120, 
-                                earliest_allowed_onset = NULL) {
+                                earliest_allowed_onset = NULL,
+                                direction = "onset") {
   
+  if (direction %in% "onset") {
+    direction_fn <- rev
+  }else if (direction %in% "report") {
+    direction_fn <- function(x){x}
+  }
   ## Reverse cases so starts with current first
-  reversed_cases <- rev(reported_cases$confirm)
+  reversed_cases <- direction_fn(reported_cases$confirm)
   
   ## Draw from the density fn of the delay dist
   delay_draw <- delay_fn(0:max_delay, dist = TRUE, cum = FALSE)
@@ -38,13 +50,23 @@ sample_approx_delay <- function(reported_cases = NULL,
                                       delay_draw,
                                     rep(0, length(reversed_cases) - .)))
   
+  
+  ## Set dates order based on direction mapping
+  if (direction %in% "onset") {
+    dates <- seq(min(reported_cases$date) - lubridate::days(length(delay_draw) - 1),
+                 max(reported_cases$date), by = "days")
+  }else if (direction %in% "report") {
+    dates <- seq(min(reported_cases$date),
+                 max(reported_cases$date)  + lubridate::days(length(delay_draw) - 1),
+                                                             by = "days")
+  }
+  
   ## Summarise imputed onsets and build output data.table
   onset_cases <- data.table::data.table(
-    date = seq(min(reported_cases$date) - lubridate::days(length(delay_draw) - 1),
-               max(reported_cases$date), by = "days"),
+    date = dates,
     ## This step will round to zero days when cases < 0 on average
     ## This can lead to a slight reduction in case count early on
-    cases = as.integer(rev(rowSums(onset_cases)))
+    cases = as.integer(direction_fn(rowSums(onset_cases)))
   )
   
   ## Filter out all zero cases until first recorded case
@@ -53,6 +75,11 @@ sample_approx_delay <- function(reported_cases = NULL,
   
   if (!is.null(earliest_allowed_onset)) {
     onset_cases <- onset_cases[date >= as.Date(earliest_allowed_onset)]
+  }
+  
+  ## Filter out future cases that have yet to report
+  if (direction %in% "report") {
+    onset_cases <- onset_cases[date <= max(reported_cases$date)]
   }
   
   return(onset_cases)

--- a/inst/templates/_region-report.Rmd
+++ b/inst/templates/_region-report.Rmd
@@ -15,12 +15,16 @@ library(tibble)
 library(knitr)
 library(kableExtra)
 library(here)
+
+if (!exists("case_def")) {
+  case_def <- "case"
+}
 ```
 
 `r paste(c(rep("#", title_depth), paste0(" Summary (estimates as of the ", latest_date, ")")), collapse = "")`
 
 
-`r paste0("*Table ",  summary_tables + index, ": Latest estimates (as of the ", latest_date,  ") of the number of confirmed cases by date of infection, the expected change in daily confirmed cases, the effective reproduction number, the doubling time (when negative this corresponds to the halving time), and the adjusted R-squared of the exponential fit. The mean and 90% credible interval is shown for each numeric estimate.*")`
+`r paste0("*Table ",  summary_tables + index, ": Latest estimates (as of the ", latest_date,  ") of the number of confirmed ", case_def, "s by date of infection, the expected change in daily confirmed ", case_def, "s, the effective reproduction number, the doubling time (when negative this corresponds to the halving time), and the adjusted R-squared of the exponential fit. The mean and 90% credible interval is shown for each numeric estimate.*")`
 <br>
 ```{r}
 readRDS(here::here(file.path(region_path, region, "latest/region_summary.rds"))) %>% 
@@ -30,14 +34,14 @@ knitr::kable(col.names = c("", "Estimate"), booktabs = TRUE) %>%
 ```
 
 
-`r paste(c(rep("#", title_depth), " Reported confirmed cases, their estimated date of infection, and time-varying reproduction number estimates"), collapse = "")`
+`r paste(c(rep("#", title_depth), " Confirmed ", case_def, "s, their estimated date of infection, and time-varying reproduction number estimates"), collapse = "")`
 
 ```{r, fig.height = 6, fig.width = 8, out.width = "90%"}
 knitr::include_graphics(here::here(file.path(region_path, region, "latest/rt_cases_plot.png")))
 ```
 
 <br>
-`r paste0("*Figure ",  summary_figures + 1 + (index - 1) * 2, ": A.) Confirmed cases by date of report (bars) and their estimated date of infection. B.) Time-varying estimate of the effective reproduction number. Light ribbon = 90% credible interval; dark ribbon = the 50% credible interval. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),  ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ",  summary_figures + 1 + (index - 1) * 2, ": A.) Confirmed ",  case_def, "s by date of report (bars) and their estimated date of infection. B.) Time-varying estimate of the effective reproduction number. Light ribbon = 90% credible interval; dark ribbon = the 50% credible interval. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),  ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
 
 `r paste(c(rep("#", title_depth), " Time-varying rate of growth and doubling time"), collapse = "")`
 

--- a/inst/templates/_regional-summary.Rmd
+++ b/inst/templates/_regional-summary.Rmd
@@ -37,7 +37,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "summary_plot.png")))
 <br>
 `r paste0("*Figure ", fig_start, ": Confirmed ", case_def, "s with date of infection on the ", latest_date, " and the time-varying estimate of the effective reproduction number (light bar = 90% credible interval; dark bar = the 50% credible interval.). Regions are ordered by the number of expected daily confirmed ",  case_def, "s and shaded based on the expected change in daily confirmed" , case_def,  "s. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control and a single case required for elimination.*")`
 
-`r paste0("Reproduction numbers over time in the six regions expected to have the most new confirmed ",  case_def, "s")`
+`r paste0("### Reproduction numbers over time in the six regions expected to have the most new confirmed ",  case_def, "s")`
 
 ```{r, fig.height = 6, fig.width = 8, layout="l-body-outset", out.width = "95%"}
 knitr::include_graphics(here::here(file.path(summary_path, "high_cases_rt_plot.png")))
@@ -46,7 +46,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "high_cases_rt_plot.p
 <br>
 `r paste0("*Figure ", fig_start + 1, ": Time-varying estimate of the effective reproduction number (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed ", case_def,  "s. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control. The vertical dashed line indicates the date of report generation.*")`
 
-`r paste0("Confirmed ",  case_def, "s and their estimated date of infection in the six regions expected to have the most new confirmed ", case_def, "s")`
+`r paste0("### Confirmed ",  case_def, "s and their estimated date of infection in the six regions expected to have the most new confirmed ", case_def, "s")`
 
 ```{r, fig.height = 6, fig.width = 8, layout="l-body-outset", out.width = "95%"}
 knitr::include_graphics(here::here(file.path(summary_path, "high_cases_plot.png")))
@@ -64,7 +64,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "rt_plot.png")))
 <br>
 `r paste0("*Figure ",  fig_start + 3, ": Time-varying estimate of the effective reproduction number (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates from existing data are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control. The vertical dashed line indicates the date of report generation.*")`
 
-`r paste0("Confirmed ",  case_def, "s and their estimated date of infection in all regions")`
+`r paste0("### Confirmed ",  case_def, "s and their estimated date of infection in all regions")`
 
 
 ```{r, fig.height = 12, fig.width = 8, layout="l-body-outset", out.width = "90%"}

--- a/inst/templates/_regional-summary.Rmd
+++ b/inst/templates/_regional-summary.Rmd
@@ -10,43 +10,50 @@ require(knitr)
 require(kableExtra)
 require(here)
 
-if (is.null(fig_start) & is.null(tab_start)) {
-    if (standalone) {
-      fig_start <- 1
-      tab_start <- 1
-    }else{
+if (standalone) {
+  fig_start <- 1
+  tab_start <- 1
+  }else{
+    if (!exists("fig_start")) {
       fig_start <- 4
+      }
+    
+    if (!exists("tab_start")) {
       tab_start <- 2
     }
+  }
+
+if (!exists("case_def")) {
+  case_def <- "case"
 }
 ```
 
-### Summary of latest reproduction number and confirmed case count estimates by date of infection
+`r paste0("### Summary of latest reproduction number and confirmed ",  case_def, " count estimates by date of infection")`
 
 ```{r, fig.height = 8, fig.width = 12, out.width = "95%"}
 knitr::include_graphics(here::here(file.path(summary_path, "summary_plot.png")))
 ```
 
 <br>
-`r paste0("*Figure ", fig_start, ": Confirmed cases with date of infection on the ", latest_date, " and the time-varying estimate of the effective reproduction number (light bar = 90% credible interval; dark bar = the 50% credible interval.). Regions are ordered by the number of expected daily confirmed cases and shaded based on the expected change in daily confirmed cases. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control and a single case required for elimination.*")`
+`r paste0("*Figure ", fig_start, ": Confirmed ", case_def, "s with date of infection on the ", latest_date, " and the time-varying estimate of the effective reproduction number (light bar = 90% credible interval; dark bar = the 50% credible interval.). Regions are ordered by the number of expected daily confirmed ",  case_def, "s and shaded based on the expected change in daily confirmed" , case_def,  "s. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control and a single case required for elimination.*")`
 
-### Reproduction numbers over time in the six regions expected to have the most new confirmed cases
+`r paste0("Reproduction numbers over time in the six regions expected to have the most new confirmed ",  case_def, "s")`
 
 ```{r, fig.height = 6, fig.width = 8, layout="l-body-outset", out.width = "95%"}
 knitr::include_graphics(here::here(file.path(summary_path, "high_cases_rt_plot.png")))
 ```
 
 <br>
-`r paste0("*Figure ", fig_start + 1, ": Time-varying estimate of the effective reproduction number (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed cases. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ", fig_start + 1, ": Time-varying estimate of the effective reproduction number (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed ", case_def,  "s. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control. The vertical dashed line indicates the date of report generation.*")`
 
-### Reported confirmed cases and their estimated date of infection in the six regions expected to have the most new confirmed cases
+`r paste0("Confirmed ",  case_def, "s and their estimated date of infection in the six regions expected to have the most new confirmed ", case_def, "s")`
 
 ```{r, fig.height = 6, fig.width = 8, layout="l-body-outset", out.width = "95%"}
 knitr::include_graphics(here::here(file.path(summary_path, "high_cases_plot.png")))
 ```
 
 <br>
-`r paste0("*Figure ", fig_start + 2, ": Confirmed cases by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed cases.  Estimates from existing data are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ", fig_start + 2, ": Confirmed ", case_def,  "s by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed ", case_def, "s.  Estimates from existing data are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
 
 ### Reproduction numbers over time in all regions
 
@@ -57,19 +64,19 @@ knitr::include_graphics(here::here(file.path(summary_path, "rt_plot.png")))
 <br>
 `r paste0("*Figure ",  fig_start + 3, ": Time-varying estimate of the effective reproduction number (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates from existing data are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control. The vertical dashed line indicates the date of report generation.*")`
 
+`r paste0("Confirmed ",  case_def, "s and their estimated date of infection in all regions")`
 
-### Reported confirmed cases and their estimated date of infection in all regions
 
 ```{r, fig.height = 12, fig.width = 8, layout="l-body-outset", out.width = "90%"}
 knitr::include_graphics(here::here(file.path(summary_path, "cases_plot.png")))
 ```
 
-`r paste0("*Figure ",  fig_start + 4, ": Confirmed cases by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ",  fig_start + 4, ": Confirmed ", case_def,  "s by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),". Confidence in the estimated values is indicated by translucency with increased translucency corresponding to reduced confidence. The vertical dashed line indicates the date of report generation.*")`
 
 `r paste0("### Latest estimates (as of the ", latest_date, ")")`
 
 
-`r paste0("*Table ",  tab_start, ": Latest estimates (as of the ", latest_date, ") of the number of confirmed cases by date of infection, the effective reproduction number, and the doubling time (when negative this corresponds to the halving time) in each region. The mean and 90% credible interval is shown.*")`
+`r paste0("*Table ",  tab_start, ": Latest estimates (as of the ", latest_date, ") of the number of confirmed ", case_def, "s by date of infection, the effective reproduction number, and the doubling time (when negative this corresponds to the halving time) in each region. The mean and 90% credible interval is shown.*")`
 <br>
 ```{r, layout="l-body-outset", out.width = "90%"}
 readRDS(here::here(file.path(summary_path, "summary_table.rds"))) %>% 


### PR DESCRIPTION
* Onsets can now be modified on a regional basis
* Changed structure of onset modifying function to need a local and import subsection
* Made Rmd templates take a case definition
* Improved the modularity of figure labels for different use cases. 
* Added nowcasting of imported as well as local cases
* Made approximate delay mapping possible from onsets -> reports as well as from onsets to reports
* Removed `national` option from `regional_rt_pipeline` as not used. 